### PR TITLE
ヘッダーの「技術記事」を「技術関連記事」に変更

### DIFF
--- a/src/components/HamburgerMenu.tsx
+++ b/src/components/HamburgerMenu.tsx
@@ -27,7 +27,7 @@ type MenuItem = {
 
 const MENU_ITEMS: MenuItem[] = [
   { href: '/', icon: FaHome, text: 'トップページ' },
-  { href: '/articles/tech', icon: FaLaptopCode, text: '技術記事' },
+  { href: '/articles/tech', icon: FaLaptopCode, text: '技術関連記事' },
   { href: '/articles/books', icon: FaBook, text: '読んだ本' },
   { href: '/articles/hobby', icon: FaGamepad, text: '趣味' },
   { href: '/profile', icon: FaUser, text: 'プロフィール' },

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -20,7 +20,7 @@ type SocialLink = {
 };
 
 const NAV_LINKS: NavLink[] = [
-  { href: '/articles/tech', icon: FaLaptopCode, text: '技術記事' },
+  { href: '/articles/tech', icon: FaLaptopCode, text: '技術関連記事' },
   { href: '/articles/books', icon: FaBook, text: '読んだ本' },
   { href: '/articles/hobby', icon: FaGamepad, text: '趣味' },
 ];


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

ヘッダー周りのナビゲーションで表示していた「技術記事」ラベルを「技術関連記事」に変更しました。

## 変更内容

- `Header.tsx`: デスクトップ用ナビのリンクテキストを更新
- `HamburgerMenu.tsx`: モバイル用ドロワーメニューの同項目を更新（ヘッダー内のハンバーガーメニュー）

カテゴリ一覧ページのタイトル（`CATEGORY_CONFIG`）やフッターのリンク文言は変更していません。必要であれば別途揃えられます。

## 確認

- `npm run lint`（`npm install --legacy-peer-deps` 後）で ESLint エラーなし
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://ryoheifreespace.slack.com/archives/D0AUT1K70MS/p1776896320138889?thread_ts=1776896320.138889&cid=D0AUT1K70MS)

<div><a href="https://cursor.com/agents/bc-3b1bbdca-edb9-414b-8ed9-60ed106fca28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3b1bbdca-edb9-414b-8ed9-60ed106fca28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

